### PR TITLE
Remove bash -e arg to allow script to handle errors

### DIFF
--- a/install-domino.sh
+++ b/install-domino.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -x
 
 HOSTNAME=$1
 QUAY_USERNAME=$2


### PR DESCRIPTION
We use the grep exit code to determine whether namespaces, etc. exist or need to be created. The script will now continue as expected even if grep does not match the pattern.